### PR TITLE
handle case sensitivity for severity input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -71,11 +71,12 @@ runs:
     - name: Check Severity Level in ZAP Report
       run: |
         # Map severity threshold to risk code (0=Informational, 1=Low, 2=Medium, 3=High)
-        case "${{ inputs.severity_threshold }}" in
-          High)           RISK_CODE=3 ;;
-          Medium)         RISK_CODE=2 ;;
-          Low)            RISK_CODE=1 ;;
-          Informational)  RISK_CODE=0 ;;
+        SEVERITY_THRESHOLD="$(echo "${{ inputs.severity_threshold }}" | tr '[:upper:]' '[:lower:]')"
+        case "$SEVERITY_THRESHOLD" in
+          high)           RISK_CODE=3 ;;
+          medium)         RISK_CODE=2 ;;
+          low)            RISK_CODE=1 ;;
+          informational)  RISK_CODE=0 ;;
           *)              echo "Invalid severity threshold"; exit 1 ;;
         esac
 


### PR DESCRIPTION
People mistakenly input "High" instead of "high" (I did :sweat_smile: ) and this will cause the step to fail.
And this happens only after the whole scan happens and the file is sent.
![image](https://github.com/user-attachments/assets/f18476a1-0b4b-41ca-a114-65c7d0d0258a)
Consider handling case sensitivity